### PR TITLE
Integrate Express server

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,75 +1,45 @@
-import {mkdtempSync,rmdirSync,readFileSync} from "node:fs";
+import express from 'express';
+import { ExpressAdapter } from '@bull-board/express';
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { mkdtempSync, rmdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
-import { Worker,Queue } from 'bullmq';
+import { Worker, Queue } from 'bullmq';
 import { connection } from './redis-connection.js';
-import {MINIO_BUCKET_NAME,clientPromise} from "./minio.js";
-import {v4 as uuidv4} from "uuid";
+import { MINIO_BUCKET_NAME, clientPromise } from './minio.js';
+import { v4 as uuidv4 } from 'uuid';
 
-
-console.log("this is index.js");
-
-function makeJobId(){
-  const jobId = uuidv4();
-  return jobId;
+function makeJobId() {
+  return uuidv4();
 }
+
+const jobQueue = new Queue('job_queue', { connection });
 
 new Worker(
   'job_queue',
   async (job) => {
-
-    console.time("task");
-    
+    console.time('task');
     const client = await clientPromise;
-
     const jobId = job.id;
-
     const temp = mkdtempSync(join(tmpdir(), 'blender-'));
-
-    try{
-
-      await new Promise<void>((resolve)=>{
-        const pythonWorker = spawn("python",[
-          "render_worker.py",
-          temp,
-        ],{
-          stdio: 'inherit'
+    try {
+      await new Promise<void>((resolve) => {
+        const pythonWorker = spawn('python', ['render_worker.py', temp], {
+          stdio: 'inherit',
         });
-        pythonWorker.on("close",(code)=>{
+        pythonWorker.on('close', () => {
           resolve();
-        })
-      })
-
-      const path=join(temp,"test.png");
-
-      const buffer= readFileSync(path);
-      await client.putObject(MINIO_BUCKET_NAME,`${jobId}/test.png`,buffer);
-
-    }finally{
-      rmdirSync(temp,{
-        recursive:true,
+        });
       });
+      const path = join(temp, 'test.png');
+      const buffer = readFileSync(path);
+      await client.putObject(MINIO_BUCKET_NAME, `${jobId}/test.png`, buffer);
+    } finally {
+      rmdirSync(temp, { recursive: true });
     }
-
-
-    // const inputStream = await client.getObject(MINIO_BUCKET_NAME,`${jobId}/input.txt`);
-
-    // const buffers = [];
-
-    // // node.js readable streams implement the async iterator protocol
-    // for await (const data of inputStream) {
-    //   buffers.push(data);
-    // }
-
-    // const message = Buffer.concat(buffers).toString("utf8");
-
-    // await client.putObject(MINIO_BUCKET_NAME,`${jobId}/output.txt`,"hello " + message);
-
-
-    console.timeEnd("task");
-
-
+    console.timeEnd('task');
     return { result: `job ${job.id} done` };
   },
   {
@@ -78,23 +48,24 @@ new Worker(
   },
 );
 
-// TODO: backendイメージで追加する
-{
-  const queue=new Queue("job_queue",{
-    connection,
-  });
+const app = express();
+app.use(express.json());
 
+const serverAdapter = new ExpressAdapter();
+serverAdapter.setBasePath('/queues');
+createBullBoard({ queues: [new BullMQAdapter(jobQueue)], serverAdapter });
+app.use('/queues', serverAdapter.getRouter());
+
+app.post('/jobs', async (req, res) => {
   const jobId = makeJobId();
-
-  queue.add("mytask",{foo:"bar"},{
-    removeOnComplete: {
-      count:1000,
-    },
+  await jobQueue.add('mytask', req.body ?? {}, {
+    removeOnComplete: { count: 1000 },
     jobId,
-  })
+  });
+  res.json({ jobId });
+});
 
-}
-
-
-
-
+const port = Number(process.env.PORT) || 4000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a simple Express server in backend/src/index.ts

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685a94548b388321ae206a6bce556b8b