### PR TITLE
List all jobs on homepage

### DIFF
--- a/backend/src/express.ts
+++ b/backend/src/express.ts
@@ -120,6 +120,20 @@ app.get('/api/jobs/:id/events', async (req, res) => {
   queueEvents.on('failed', onFailed);
 });
 
+app.get('/api/jobs', async (_req, res) => {
+  const jobs = await jobQueue.getJobs([
+    'waiting',
+    'active',
+    'completed',
+    'failed',
+    'delayed',
+  ]);
+  const jobInfos = await Promise.all(
+    jobs.map(async (job) => ({ jobId: job.id, state: await job.getState() }))
+  );
+  res.json({ jobs: jobInfos });
+});
+
 app.get('/api/jobs/:id', async (req, res) => {
   const { id } = req.params;
   const job = await jobQueue.getJob(id);

--- a/next-app/src/app/jobs/page.tsx
+++ b/next-app/src/app/jobs/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
 export default function JobsPage() {
   const [jobs, setJobs] = useState<{ jobId: string; state: string }[]>([]);
@@ -21,7 +22,7 @@ export default function JobsPage() {
       <ul>
         {jobs.map((job) => (
           <li key={job.jobId}>
-            <a href={`/jobs/${job.jobId}`}>{job.jobId}</a> - {job.state}
+            <Link href={`/jobs/${job.jobId}`}>{job.jobId}</Link> - {job.state}
           </li>
         ))}
       </ul>

--- a/next-app/src/app/jobs/page.tsx
+++ b/next-app/src/app/jobs/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function JobsPage() {
+  const [jobs, setJobs] = useState<{ jobId: string; state: string }[]>([]);
+
+  useEffect(() => {
+    async function fetchJobs() {
+      const res = await fetch("/api/jobs");
+      if (res.ok) {
+        const data = await res.json();
+        setJobs(data.jobs as { jobId: string; state: string }[]);
+      }
+    }
+    fetchJobs();
+  }, []);
+
+  return (
+    <div>
+      <h1>Jobs</h1>
+      <ul>
+        {jobs.map((job) => (
+          <li key={job.jobId}>
+            <a href={`/jobs/${job.jobId}`}>{job.jobId}</a> - {job.state}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -1,22 +1,11 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import styles from "./page.module.scss";
 
 export default function Home() {
   const [jobId, setJobId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [jobs, setJobs] = useState<{ jobId: string; state: string }[]>([]);
-
-  useEffect(() => {
-    async function fetchJobs() {
-      const res = await fetch("/api/jobs");
-      if (res.ok) {
-        const data = await res.json();
-        setJobs(data.jobs as { jobId: string; state: string }[]);
-      }
-    }
-    fetchJobs();
-  }, []);
+  // home page only links to the job list page
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -51,13 +40,7 @@ export default function Home() {
         </p>
       )}
       {error && <p>{error}</p>}
-      <ul>
-        {jobs.map((job) => (
-          <li key={job.jobId}>
-            <a href={`/jobs/${job.jobId}`}>{job.jobId}</a> - {job.state}
-          </li>
-        ))}
-      </ul>
     </div>
   );
 }
+

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import Link from "next/link";
 import styles from "./page.module.scss";
 
 export default function Home() {
@@ -27,7 +28,7 @@ export default function Home() {
     <div className={styles["page"]}>
       <h1 className={styles["page"]}>Title</h1>
       <p>
-        <a href="/jobs">All Jobs</a>
+        <Link href="/jobs">All Jobs</Link>
       </p>
       <form onSubmit={handleSubmit} className={styles["page__form"]}>
         <input type="text" name="name" placeholder="name" required />
@@ -36,7 +37,7 @@ export default function Home() {
       </form>
       {jobId && (
         <p>
-          JobId: <a href={`/jobs/${jobId}`}>{jobId}</a>
+          JobId: <Link href={`/jobs/${jobId}`}>{jobId}</Link>
         </p>
       )}
       {error && <p>{error}</p>}

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -1,23 +1,11 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import styles from "./page.module.scss";
 
 export default function Home() {
   const [jobId, setJobId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [jobs, setJobs] = useState<{ jobId: string; state: string }[]>([]);
 
-  async function fetchJobs() {
-    const res = await fetch("/api/jobs");
-    if (res.ok) {
-      const data = await res.json();
-      setJobs(data.jobs as { jobId: string; state: string }[]);
-    }
-  }
-
-  useEffect(() => {
-    fetchJobs();
-  }, []);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -30,7 +18,6 @@ export default function Home() {
     if (res.ok) {
       const data = await res.json();
       setJobId(data.jobId as string);
-      fetchJobs();
     } else {
       setError("failed to create job");
     }
@@ -49,13 +36,6 @@ export default function Home() {
           JobId: <a href={`/jobs/${jobId}`}>{jobId}</a>
         </p>
       )}
-      <ul>
-        {jobs.map((job) => (
-          <li key={job.jobId}>
-            <a href={`/jobs/${job.jobId}`}>{job.jobId}</a> - {job.state}
-          </li>
-        ))}
-      </ul>
       {error && <p>{error}</p>}
     </div>
   );

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -1,11 +1,22 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styles from "./page.module.scss";
 
 export default function Home() {
   const [jobId, setJobId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [jobs, setJobs] = useState<{ jobId: string; state: string }[]>([]);
 
+  useEffect(() => {
+    async function fetchJobs() {
+      const res = await fetch("/api/jobs");
+      if (res.ok) {
+        const data = await res.json();
+        setJobs(data.jobs as { jobId: string; state: string }[]);
+      }
+    }
+    fetchJobs();
+  }, []);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -37,6 +48,16 @@ export default function Home() {
         </p>
       )}
       {error && <p>{error}</p>}
+      <p>
+        <a href="/jobs">All Jobs</a>
+      </p>
+      <ul>
+        {jobs.map((job) => (
+          <li key={job.jobId}>
+            <a href={`/jobs/${job.jobId}`}>{job.jobId}</a> - {job.state}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -1,10 +1,23 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styles from "./page.module.scss";
 
 export default function Home() {
   const [jobId, setJobId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [jobs, setJobs] = useState<{ jobId: string; state: string }[]>([]);
+
+  async function fetchJobs() {
+    const res = await fetch("/api/jobs");
+    if (res.ok) {
+      const data = await res.json();
+      setJobs(data.jobs as { jobId: string; state: string }[]);
+    }
+  }
+
+  useEffect(() => {
+    fetchJobs();
+  }, []);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -17,6 +30,7 @@ export default function Home() {
     if (res.ok) {
       const data = await res.json();
       setJobId(data.jobId as string);
+      fetchJobs();
     } else {
       setError("failed to create job");
     }
@@ -35,6 +49,13 @@ export default function Home() {
           JobId: <a href={`/jobs/${jobId}`}>{jobId}</a>
         </p>
       )}
+      <ul>
+        {jobs.map((job) => (
+          <li key={job.jobId}>
+            <a href={`/jobs/${job.jobId}`}>{job.jobId}</a> - {job.state}
+          </li>
+        ))}
+      </ul>
       {error && <p>{error}</p>}
     </div>
   );

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -37,6 +37,9 @@ export default function Home() {
   return (
     <div className={styles["page"]}>
       <h1 className={styles["page"]}>Title</h1>
+      <p>
+        <a href="/jobs">All Jobs</a>
+      </p>
       <form onSubmit={handleSubmit} className={styles["page__form"]}>
         <input type="text" name="name" placeholder="name" required />
         <input type="file" name="image" accept="image/jpeg" required />
@@ -48,9 +51,6 @@ export default function Home() {
         </p>
       )}
       {error && <p>{error}</p>}
-      <p>
-        <a href="/jobs">All Jobs</a>
-      </p>
       <ul>
         {jobs.map((job) => (
           <li key={job.jobId}>


### PR DESCRIPTION
## Summary
- expose `/api/jobs` to return all jobs
- show job list on the Next.js homepage

## Testing
- `npm --prefix backend run build` *(fails: Cannot find module)*
- `npm --prefix next-app run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ed3ced7483219b8157d364630467